### PR TITLE
Feature/limit the use of sitecore query

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Repository's directory "src" contains "Roslyn" folder where C# solution "ScLint"
 | 3. | ScLint3 | Do not use hard coded paths to get Sitecore items | Rule checks variable declarations and return statements to catch all occurrences of obsolete way of referencing items - searching them by providing their paths and using following methods: <i>GetItem</i>, <i>GetRootItem</i>, <i>SelectItems</i>, <i>SelectItemsUsingXPath</i>, <i>SelectSingleItem</i>,  <i>SelectSingleItemUsingXPath</i>. Code analyzer suggests to give items' guids instead of paths and to use other methods to get them.<br>Type: warning | HardCodedPaths |
 | 4. | ScLint4 | Do not use GUIDs of unknown items | Rule checks if GUIDs are used as method arguments or as attributes in code - then reports a warning. GUIDs can be provided only while assigning to variables.<br>Type: warning | HardCodedGuids |
 | 5. | ScLint5 | Do not use hard coded image paths | Rule checks if paths to media library items are used direct (being not wrapped in variables) in methods as parameters. This approach is reported as a warning since paths should be assigned to variables to suggest which items they are referring to.<br>Type: warning |  HardCodedImagePaths |
+| 6. | ScLint6 | Limit use of Sitecore Query | Every occurrence of string containing <em>query:/</em> phrase is listed as possible Sitecore query and suggestion to change the way of referencing items is displayed.<br>Type: warning | QueryLimit
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Repository's directory "src" contains "Roslyn" folder where C# solution "ScLint"
 | 4. | ScLint4 | Do not use GUIDs of unknown items | Rule checks if GUIDs are used as method arguments or as attributes in code - then reports a warning. GUIDs can be provided only while assigning to variables.<br>Type: warning | HardCodedGuids |
 | 5. | ScLint5 | Do not use hard coded image paths | Rule checks if paths to media library items are used direct (being not wrapped in variables) in methods as parameters. This approach is reported as a warning since paths should be assigned to variables to suggest which items they are referring to.<br>Type: warning |  HardCodedImagePaths |
 | 6. | ScLint6 | Limit use of Sitecore Query | Every occurrence of string containing <em>query:/</em> phrase is listed as possible Sitecore query and suggestion to change the way of referencing items is displayed.<br>Type: warning | QueryLimit
+| 7. | ScLint7 | Limit use of Sitecore API get items methods | <em>GetAncestors</em> and <em>GetDescendants</em> methods are highlighted for discarding them and replacing with other ways of item getting.<br>Type: warning | GetMethodsLimit
 
 ## Development
 

--- a/src/ScLint/GetMethodsLimit/GetMethodsLimitAnalyzer.cs
+++ b/src/ScLint/GetMethodsLimit/GetMethodsLimitAnalyzer.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+namespace GetMethodsLimit
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    class GetMethodsLimitAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "ScLint7";
+        private const string Title = "Consider getting Sitecore items with the use of other methods";
+        private const string Category = "Limit use of get methods API calls";
+
+        private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, Title, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Title);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.IdentifierName);
+        }
+
+        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            var nodeText = context.Node.GetText().ToString().ToLower();
+
+            Regex regEx = new Regex(@"(getancestors|getdescendants)");
+
+            if (regEx.Match(nodeText).Success)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation()));
+            }
+        }
+    }
+}

--- a/src/ScLint/GetMethodsLimit/GetMethodsLimitCodeFixProvider.cs
+++ b/src/ScLint/GetMethodsLimit/GetMethodsLimitCodeFixProvider.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+
+namespace GetMethodsLimit
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(GetMethodsLimitCodeFixProvider)), Shared]
+    public class GetMethodsLimitCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get { return ImmutableArray.Create(GetMethodsLimitAnalyzer.DiagnosticId); }
+        }
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+
+        }
+    }
+}

--- a/src/ScLint/QueryLimit/QueryLimitAnalyzer.cs
+++ b/src/ScLint/QueryLimit/QueryLimitAnalyzer.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+namespace QueryLimit
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    class QueryLimitAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "ScLint6";
+        private const string Title = "Try to limit Sitecore queries and reference items in other way";
+        private const string Category = "Limit Sitecore queries";
+
+        private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, Title, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Title);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.StringLiteralExpression);
+        }
+
+        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            var nodeText = context.Node.GetText().ToString().ToLower();
+
+            Regex regEx = new Regex(@"query:/");
+
+            if (regEx.Match(nodeText).Success)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation()));
+            }
+        }
+    }
+}

--- a/src/ScLint/QueryLimit/QueryLimitCodeFixProvider.cs
+++ b/src/ScLint/QueryLimit/QueryLimitCodeFixProvider.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+
+namespace QueryLimit
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(QueryLimitCodeFixProvider)), Shared]
+    public class QueryLimitCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get { return ImmutableArray.Create(QueryLimitAnalyzer.DiagnosticId); }
+        }
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
I'm wondering whether also methods referring to single items should be included (like GetAncestor() or GetDescendant()).